### PR TITLE
Add HTTP endpoint to web-fetch for submitting URLs


### DIFF
--- a/web-fetch/composer.json
+++ b/web-fetch/composer.json
@@ -23,10 +23,7 @@
         }
     ],
     "scripts": {
-        "start": [
-            "Composer\\Config::disableProcessTimeout",
-            "FUNCTION_TARGET=webFetch php -S localhost:${PORT:-8080} vendor/google/cloud-functions-framework/router.php"
-        ]
+        "start": "php -S localhost:${PORT:-8080} vendor/google/cloud-functions-framework/router.php"
     },
     "autoload": {
         "psr-4": {

--- a/web-fetch/index.php
+++ b/web-fetch/index.php
@@ -4,6 +4,9 @@ require_once __DIR__ . '/vendor/autoload.php';
 
 use Google\CloudFunctions\FunctionsFramework;
 use CloudEvents\V1\CloudEventInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use GuzzleHttp\Psr7\Response;
 use yananob\MyTools\Logger;
 use yananob\MyTools\Trigger;
 use yananob\MyTools\Utils;
@@ -12,10 +15,15 @@ use yananob\MyTools\Raindrop;
 
 // CloudEventを処理するメイン関数
 // 設定されたタイミングで指定されたURLをPocketおよびRaindropに追加する
-FunctionsFramework::cloudEvent('main', 'main');
-function main(CloudEventInterface $event): void
+FunctionsFramework::cloudEvent('main_event', 'main_event');
+
+// HTTPリクエストを処理するメイン関数
+// 指定されたURLをPocketおよびRaindropに追加する
+FunctionsFramework::http('main_http', 'main_http');
+
+function main_event(CloudEventInterface $event): void
 {
-    $logger = new Logger("web-fetch");
+    $logger = new Logger("web-fetch-event");
     $trigger = new Trigger();
 
     $config = Utils::getConfig(dirname(__FILE__) . "/configs/config.json");
@@ -33,4 +41,37 @@ function main(CloudEventInterface $event): void
     };
 
     $logger->log("Succeeded.");
+}
+
+function main_http(ServerRequestInterface $request): ResponseInterface
+{
+    $logger = new Logger("web-fetch-http");
+
+    $body = $request->getParsedBody();
+    $url = $body['url'] ?? null;
+
+    if (empty($url)) {
+        $logger->log("URL not provided.");
+        return new Response(400, ['Content-Type' => 'text/plain'], 'URL not provided');
+    }
+
+    $logger->log("Received URL: " . $url);
+
+    try {
+        $pocket = new Pocket(__DIR__ . '/configs/pocket.json');
+        $raindrop = new Raindrop(__DIR__ . '/configs/raindrop.json');
+
+        $logger->log("Adding to Pocket...");
+        $pocket->add($url);
+        $logger->log("URL added to Pocket successfully.");
+
+        $logger->log("Adding to Raindrop...");
+        $raindrop->add($url);
+        $logger->log("URL added to Raindrop successfully.");
+
+        return new Response(200, ['Content-Type' => 'text/plain'], 'URL added successfully to Pocket and Raindrop');
+    } catch (\Exception $e) {
+        $logger->log("Error adding URL: " . $e->getMessage());
+        return new Response(500, ['Content-Type' => 'text/plain'], 'Error adding URL: ' . $e->getMessage());
+    }
 }

--- a/web-fetch/tests/listen_local_http.sh
+++ b/web-fetch/tests/listen_local_http.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -eu
+
+export FUNCTION_TARGET=main_http
+composer start

--- a/web-fetch/tests/trigger_http_local.sh
+++ b/web-fetch/tests/trigger_http_local.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -eu
+
+curl -X POST \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    -d "url=http://example.com/testpage" \
+    http://localhost:8080
+echo "" # Add a newline for cleaner output in terminal


### PR DESCRIPTION
This commit introduces an HTTP endpoint to the web-fetch service,
allowing URLs to be submitted via a POST request (e.g., from a form).
The endpoint takes a 'url' parameter and adds it to Pocket and Raindrop.

Changes include:
- Modified `web-fetch/index.php`:
    - Added `main_http` function to handle HTTP requests.
    - Registered `main_http` with `FunctionsFramework::http`.
    - Renamed existing CloudEvent handler to `main_event` and updated its registration.
    - Ensured distinct logging for HTTP and event handlers.
- Added test scripts:
    - `web-fetch/tests/trigger_http_local.sh`: Sends a test POST request.
    - `web-fetch/tests/listen_local_http.sh`: Starts a local server for `main_http`.
- Updated `web-fetch/composer.json`:
    - Modified the `scripts.start` command to allow `FUNCTION_TARGET` to be set externally, enabling local testing of the specific HTTP function.

You can test the new endpoint locally by running `listen_local_http.sh` in one terminal and `trigger_http_local.sh` in another.